### PR TITLE
meson: Use MESON_INSTALL_DESTDIR_PREFIX to respect DESTDIR

### DIFF
--- a/src/cinnamon/meson.build
+++ b/src/cinnamon/meson.build
@@ -45,21 +45,21 @@ foreach theme: themes
     meson.current_source_dir(),
   )
 
-  # Generate and install CSS file
-  custom_target(
+  # Generate CSS file
+  cinnamon_css = custom_target(
     'cinnamon.@0@.css'.format(theme['name']),
     input: 'cinnamon.@0@.scss'.format(theme['name']),
     output: 'cinnamon.@0@.css'.format(theme['name']),
     command: [sassc, sassc_opts, '@INPUT@', '@OUTPUT@'],
     depend_files: cinnamon_scss_depend_files,
-    install: true,
-    install_dir: cinnamon_dir,
+    build_by_default: true,
   )
 
-  # Rename it to a valid name
+  # Install it while renaming to a valid name
   meson.add_install_script(
-    'mv',
-    join_paths(get_option('prefix'), cinnamon_dir, 'cinnamon.@0@.css'.format(theme['name'])),
-    join_paths(get_option('prefix'), cinnamon_dir, 'cinnamon.css'),
+    'sh', '-c', 'cp "@0@" "@1@"'.format(
+      cinnamon_css.full_path(),
+      join_paths('$MESON_INSTALL_DESTDIR_PREFIX', cinnamon_dir, 'cinnamon.css'),
+    ),
   )
 endforeach

--- a/src/gnome-shell/meson.build
+++ b/src/gnome-shell/meson.build
@@ -121,21 +121,21 @@ foreach theme: themes
     meson.current_source_dir(),
   )
 
-  # Generate and install CSS file
-  custom_target(
+  # Generate CSS file
+  gnome_shell_css = custom_target(
     'gnome-shell.@0@.css'.format(theme['name']),
     input: 'gnome-shell.@0@.scss'.format(theme['name']),
     output: 'gnome-shell.@0@.css'.format(theme['name']),
     command: [sassc, sassc_opts, '@INPUT@', '@OUTPUT@'],
     depend_files: gnome_shell_scss_depend_files,
-    install: true,
-    install_dir: gnome_shell_dir,
+    build_by_default: true,
   )
 
-  # Rename it to a valid name
+  # Install it while renaming to a valid name
   meson.add_install_script(
-    'mv',
-    join_paths(get_option('prefix'), gnome_shell_dir, 'gnome-shell.@0@.css'.format(theme['name'])),
-    join_paths(get_option('prefix'), gnome_shell_dir, 'gnome-shell.css'),
+    'sh', '-c', 'cp "@0@" "@1@"'.format(
+      gnome_shell_css.full_path(),
+      join_paths('$MESON_INSTALL_DESTDIR_PREFIX', gnome_shell_dir, 'gnome-shell.css'),
+    ),
   )
 endforeach

--- a/src/gtk/meson.build
+++ b/src/gtk/meson.build
@@ -69,22 +69,22 @@ foreach theme: themes
         meson.current_source_dir(),
       )
 
-      # Generate and install CSS file
-      custom_target(
+      # Generate CSS file
+      gtk_css = custom_target(
         '@0@.css'.format(gtk_temp_name),
         input: '@0@.scss'.format(gtk_temp_name),
         output: '@0@.css'.format(gtk_temp_name),
         command: [sassc, sassc_opts, '@INPUT@', '@OUTPUT@'],
         depend_files: gtk_scss_depend_files,
-        install: true,
-        install_dir: gtk_version_dir,
+        build_by_default: true,
       )
 
-      # Rename it to a valid name
+      # Install it while renaming to a valid name
       meson.add_install_script(
-        'mv',
-        join_paths(get_option('prefix'), gtk_version_dir, '@0@.css'.format(gtk_temp_name)),
-        join_paths(get_option('prefix'), gtk_version_dir, 'gtk@0@.css'.format(gtk_variant)),
+        'sh', '-c', 'cp "@0@" "@1@"'.format(
+          gtk_css.full_path(),
+          join_paths('$MESON_INSTALL_DESTDIR_PREFIX', gtk_version_dir, 'gtk@0@.css'.format(gtk_variant)),
+        ),
       )
     endforeach
   endforeach


### PR DESCRIPTION
Also use meson.add_install_script() instead of custom_target() to
install CSSs.

Fixes https://github.com/nana-4/materia-theme/issues/493